### PR TITLE
Automate first PR checks via danger

### DIFF
--- a/.github/workflows/danger.yaml
+++ b/.github/workflows/danger.yaml
@@ -1,0 +1,23 @@
+name: DangerJS
+
+on: pull_request_target
+
+jobs:
+  danger:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{github.event.pull_request.head.ref}}
+        repository: ${{github.event.pull_request.head.repo.full_name}}
+        fetch-depth: 0
+    - name: Use Node.js
+      uses: actions/setup-node@v2.4.1
+      with:
+        node-version: "12.x"
+    - name: Install yarn dependencies
+      run: |
+        yarn add danger typescript --dev
+        yarn danger ci -d danger/dangerfile.ts
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/danger/classes/Rule.ts
+++ b/danger/classes/Rule.ts
@@ -1,5 +1,7 @@
 //import { DangerDSLType, message, fail } from "danger";
 
+import { danger, DangerDSLType } from "danger";
+
 export class Rule {
     private readonly checkFunction: (danger: DangerDSLType) => Promise<boolean>;
     private readonly readableName: string;
@@ -28,5 +30,18 @@ export class MapChangeRule extends Rule {
         if (danger.git.fileMatch("Map/map").modified) {
             await super.check(danger);
         }
+    }
+}
+
+export class SimpleFileChangeRule extends MapChangeRule {
+    constructor(readableName: string, filePath: string) {
+        const checkFunction = async (danger: DangerDSLType) => {
+            const file = danger.git.fileMatch(filePath);
+            if (!file.edited) {
+                return false;
+            }
+            return true;
+        }
+        super(checkFunction, readableName);
     }
 }

--- a/danger/classes/Rule.ts
+++ b/danger/classes/Rule.ts
@@ -1,0 +1,32 @@
+//import { DangerDSLType, message, fail } from "danger";
+
+export class Rule {
+    private readonly checkFunction: (danger: DangerDSLType) => Promise<boolean>;
+    private readonly readableName: string;
+
+    constructor(checkFunction: (danger: DangerDSLType) => Promise<boolean>, readableName: string) {
+        this.checkFunction = checkFunction;
+        this.readableName = readableName;
+    }
+
+    public async check(danger: DangerDSLType): Promise<void> {
+        if (await this.checkFunction(danger)) {
+            message(this.readableName);
+        } else {
+            fail(this.readableName);
+        }
+    }
+}
+
+export class MapChangeRule extends Rule {
+
+    constructor(checkFunction: (danger: DangerDSLType) => Promise<boolean>, readableName: string) {
+        super(checkFunction, readableName);
+    }
+
+    public async check(danger: DangerDSLType) {
+        if (danger.git.fileMatch("Map/map").modified) {
+            await super.check(danger);
+        }
+    }
+}

--- a/danger/dangerfile.ts
+++ b/danger/dangerfile.ts
@@ -1,0 +1,7 @@
+import {message, danger} from "danger";
+import * as rules from "./rules";
+
+Object.values(rules).forEach(rule => rule.check(danger))
+
+const newFiles = danger.git.created_files.join("- ")
+message("New Files in this PR: \n - " + newFiles);

--- a/danger/dangerfile.ts
+++ b/danger/dangerfile.ts
@@ -1,7 +1,4 @@
 import {message, danger} from "danger";
 import * as rules from "./rules";
 
-Object.values(rules).forEach(rule => rule.check(danger))
-
-const newFiles = danger.git.created_files.join("- ")
-message("New Files in this PR: \n - " + newFiles);
+Object.values(rules).forEach(rule => rule.check(danger));

--- a/danger/rules/UpdateChangelog.ts
+++ b/danger/rules/UpdateChangelog.ts
@@ -1,0 +1,3 @@
+import { SimpleFileChangeRule } from "../classes/Rule";
+
+export const updateChangelog = new SimpleFileChangeRule("Updated `changelog.txt`.", "Map/changelog.txt");

--- a/danger/rules/UpdateJsonMapFile.ts
+++ b/danger/rules/UpdateJsonMapFile.ts
@@ -1,0 +1,3 @@
+import { SimpleFileChangeRule } from "../classes/Rule";
+
+export const updateJsonMapFile = new SimpleFileChangeRule("Updated JSON map.", "Map/changelog.txt");

--- a/danger/rules/UpdateJsonMapFile.ts
+++ b/danger/rules/UpdateJsonMapFile.ts
@@ -1,3 +1,3 @@
 import { SimpleFileChangeRule } from "../classes/Rule";
 
-export const updateJsonMapFile = new SimpleFileChangeRule("Updated JSON map.", "Map/changelog.txt");
+export const updateJsonMapFile = new SimpleFileChangeRule("Updated JSON map.", "Map/map.json");

--- a/danger/rules/UpdateVersionFile.ts
+++ b/danger/rules/UpdateVersionFile.ts
@@ -1,0 +1,19 @@
+//import { DangerDSLType } from "danger";
+import { MapChangeRule } from "../classes/Rule";
+
+const versionFilePath = "Map/version.txt";
+
+export const updateVersionFile = new MapChangeRule(
+    async (danger: DangerDSLType) => {
+        const versionFile = danger.git.fileMatch(versionFilePath);
+        if (!versionFile.edited) {
+            return false;
+        }
+        const versionFileDiff = await danger.git.diffForFile(versionFilePath);
+        if (parseInt(versionFileDiff.before) + 1 != parseInt(versionFileDiff.after)) {
+            return false;
+        }
+        return true;
+    },
+    "Updated `version.txt` by 1."
+);

--- a/danger/rules/index.ts
+++ b/danger/rules/index.ts
@@ -1,1 +1,3 @@
 export * from "./UpdateVersionFile"
+export * from "./UpdateJsonMapFile"
+export * from "./UpdateChangelog"

--- a/danger/rules/index.ts
+++ b/danger/rules/index.ts
@@ -1,0 +1,1 @@
+export * from "./UpdateVersionFile"

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -1,0 +1,4 @@
+import {message, danger} from "danger"
+
+const newFiles = danger.git.created_files.join("- ")
+message("New Files in this PR: \n - " + newFiles);

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -1,4 +1,0 @@
-import {message, danger} from "danger"
-
-const newFiles = danger.git.created_files.join("- ")
-message("New Files in this PR: \n - " + newFiles);


### PR DESCRIPTION
The Mudlet team recently introduced a new tool called `danger-js` to PRs, which allows checking for custom tasks in PRs and then adding a nice table with the output. I think this is a great tool to add to our toolbelt as well.

This PR adds a workflow to run these checks on every PR as well as adding the first few checks. The included checks are:
- check, if the JSON map was changed (if the main map file was changed)
- check, if the changelog file was changed (if the main map file was changed)
- check, if the number in the version file was increased by 1 (if the main map file was changed)

These checks were relatively simple to write and are part of the PR template. If this tool is well received, it's possible and easy to add more checks and other functionality.