### PR TITLE
Show map diffs in PRs

### DIFF
--- a/.github/workflows/show-map-diffs.yml
+++ b/.github/workflows/show-map-diffs.yml
@@ -1,3 +1,5 @@
+name: Map diffs
+
 on: [pull_request]
 
 jobs:

--- a/.github/workflows/show-map-diffs.yml
+++ b/.github/workflows/show-map-diffs.yml
@@ -1,0 +1,32 @@
+on: [pull_request]
+
+jobs:
+  map-diff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{github.base_ref}}
+          path: 'base'
+          
+      - name: Check if the map was changed in this PR
+        id: map-change-detected
+        uses: tj-actions/changed-files@v11
+        with:
+          # the only source of truth is the actual map
+          files: Map/map
+        
+      - name: Create map diffs
+        if: steps.map-change-detected.outputs.any_changed == 'true'
+        uses: Delwing/mudlet-map-diff-action@v1
+        with:
+          old-map: base/Map/map
+          new-map: Map/map
+        env:
+          CLOUDINARY_NAME: ${{ secrets.CLOUDINARY_NAME }}
+          CLOUDINARY_KEY: ${{ secrets.CLOUDINARY_KEY }}
+          CLOUDINARY_SECRET: ${{ secrets.CLOUDINARY_SECRET }}

--- a/.github/workflows/show-map-diffs.yml
+++ b/.github/workflows/show-map-diffs.yml
@@ -1,6 +1,6 @@
 name: Map diffs
 
-on: [pull_request]
+on: [pull_request_target]
 
 jobs:
   map-diff:


### PR DESCRIPTION
This adds https://github.com/Delwing/mudlet-map-diff-action which'll show a diff of the map on pull requests.

Currently uses my personal cloudinary account in lieu of anything better, happy to change that. 

Once we merge this and confirm it working in the Achaea repo, I'll replicate this workflow in other repositories.