### PR TITLE
Improve map-diff workflow

### DIFF
--- a/.github/workflows/show-map-diffs.yml
+++ b/.github/workflows/show-map-diffs.yml
@@ -15,7 +15,7 @@ jobs:
           
       - name: Check if the map was changed in this PR
         id: map-change-detected
-        uses: tj-actions/changed-files@v11
+        uses: tj-actions/changed-files@v12
         with:
           # the only source of truth is the actual map
           files: Map/map

--- a/.github/workflows/show-map-diffs.yml
+++ b/.github/workflows/show-map-diffs.yml
@@ -20,7 +20,7 @@ jobs:
           # the only source of truth is the actual map
           files: Map/map
           sha: ${{github.event.pull_request.head.sha}}
-          base_sha: ${github.event.pull_request.base.sha}}
+          base_sha: ${{github.event.pull_request.base.sha}}
         
       - name: Create map diffs
         if: steps.map-change-detected.outputs.any_changed == 'true'

--- a/.github/workflows/show-map-diffs.yml
+++ b/.github/workflows/show-map-diffs.yml
@@ -19,7 +19,8 @@ jobs:
         with:
           # the only source of truth is the actual map
           files: Map/map
-          sha: ${{github.event.pull_request.head.ref}}
+          sha: ${{github.event.pull_request.head.sha}}
+          base_sha: ${github.event.pull_request.base.sha}}
         
       - name: Create map diffs
         if: steps.map-change-detected.outputs.any_changed == 'true'


### PR DESCRIPTION
This improves the map-diff workflow to allow the branch name in the fork to be the same as the target branch.