### PR TITLE
Configure map diff comment to be less spammy

### DIFF
--- a/.github/workflows/show-map-diffs.yml
+++ b/.github/workflows/show-map-diffs.yml
@@ -27,6 +27,8 @@ jobs:
         uses: Delwing/mudlet-map-diff-action@v3
         with:
           old-map: Map/map
+          reuse-comment: true
+          collapse-diff: true
         env:
           CLOUDINARY_NAME: ${{ secrets.CLOUDINARY_NAME }}
           CLOUDINARY_KEY: ${{ secrets.CLOUDINARY_KEY }}


### PR DESCRIPTION
This should:
- make the bot re-use the comment, so we don't have multiple huge comments
- make the bot surround the actual diff by a `details` tag, which should make the comment much smaller by default
