### PR TITLE
Use experimental branch of visual map diff

### DIFF
--- a/.github/workflows/show-map-diffs.yml
+++ b/.github/workflows/show-map-diffs.yml
@@ -24,7 +24,7 @@ jobs:
         
       - name: Create map diffs
         if: steps.map-change-detected.outputs.any_changed == 'true'
-        uses: Delwing/mudlet-map-diff-action@v3
+        uses: Delwing/mudlet-map-diff-action@details-tag-fix
         with:
           old-map: Map/map
           reuse-comment: true


### PR DESCRIPTION
This will (hopefully) fix the use of the details tag in the visual map diff. After the branch is merged, I'll update the action to the stable release again.
