### PR TITLE
Don't fix node version

### DIFF
--- a/.github/workflows/danger.yaml
+++ b/.github/workflows/danger.yaml
@@ -13,8 +13,6 @@ jobs:
         fetch-depth: 0
     - name: Use Node.js
       uses: actions/setup-node@v3.1.1
-      with:
-        node-version: "12.x"
     - name: Install yarn dependencies
       run: |
         yarn install --frozen-lockfile


### PR DESCRIPTION
This allows us to be more flexible in the node version we use. Right now we break with an updated danger version (see #160 )