### PR TITLE
Fix rule that disallows wormholes

### DIFF
--- a/danger/rules/DisallowUnlockedWormholes.ts
+++ b/danger/rules/DisallowUnlockedWormholes.ts
@@ -2,9 +2,14 @@ import * as _ from "lodash";
 import { RoomCheckRule } from "../classes/Rule";
 import mapModel from "../helpers/MapModel";
 
+const exitLocked = (room: MudletRoom, target: number) => {
+    return room.mSpecialExitLocks?.some(specialTarget => specialTarget === target) ?? false;
+}
+
 const rooms = _.filter(mapModel.rooms, (room) =>
-    _.some(room.mSpecialExits, (_, exitCommand) => exitCommand === "worm warp")
-        && !_.some(room.mSpecialExitLocks, (exitCommand) => exitCommand === "worm warp")
+    _.some(room.mSpecialExits, (target, exitCommand) =>
+        exitCommand === "worm warp" && !exitLocked(room, target)
+    )
 );
 
 export const disallowUnlockedWormholes = new RoomCheckRule(rooms, 'rooms with unlocked wormholes', false);


### PR DESCRIPTION
This was caused due to an uncaught change in the binary reader dependency